### PR TITLE
0.11安装脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # cSphere 自动安装脚本
 使用方法： 直接运行，根据提示输入相关参数即可
+
+# init systems
+
+Upstart:
+  CentOS 6
+  Ubuntu before 15.04
+  Fedora 9 ~ 14
+
+Systemd:
+  Centos 7
+  Ubuntu 15.04
+  Fedora >= 15
+  Debian >=7
+  CoreOS
+
+Sysv Init:
+  Amazon AMI
+
+

--- a/init/systemd/csphere-agent.service
+++ b/init/systemd/csphere-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=cSphere agent
+Documentation=https://csphere.cn/docs/
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+EnvironmentFile=/etc/default/csphere
+ExecStart=/usr/bin/csphere --tls join --addr=${CONTROLLER_ADDR}
+RestartSec=5
+Restart=true
+LimitNOFILE=2048
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/init/systemd/docker.service
+++ b/init/systemd/docker.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Docker Socket for the API
+PartOf=docker.service
+
+[Socket]
+ListenStream=/var/run/docker.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=docker
+
+[Install]
+WantedBy=sockets.target
+

--- a/init/systemd/docker.socket
+++ b/init/systemd/docker.socket
@@ -1,0 +1,16 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+ExecStart=/usr/local/bin/docker -d -H fd://
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target
+

--- a/init/upstart/csphere-agent.conf
+++ b/init/upstart/csphere-agent.conf
@@ -1,0 +1,47 @@
+description "cSphere agent"
+
+start on started docker
+stop on stopping docker
+
+respawn
+
+pre-start script
+  if [ -f /etc/default/csphere ]; then
+    . /etc/default/csphere
+  fi
+  
+  if [ -z "$AUTH_KEY" ]; then
+    echo "The AUTH_KEY must not be empty."
+    echo "Please put it in /etc/default/csphere"
+    stop
+    exit 1
+  fi
+  
+  if [ -z "$CONTROLLER_ADDR" ]; then
+    echo "The CONTROLLER_ADDR must not be empty."
+    echo "Please put it in /etc/default/csphere"
+    stop
+    exit 1
+  fi
+
+  # wait for the docker daemon
+  [ -S /var/run/docker.sock ] || {
+    logger -t $UPSTART_JOB -p daemon.error "docker daemon not running"
+    echo "docker daemon not running"
+    stop
+    exit 1
+  }
+
+  while ! docker info>/dev/null 2>&1; do
+    echo "waiting for docker remote API"
+    sleep 1
+  done
+end script
+
+script
+  if [ -f /etc/default/csphere ]; then
+    . /etc/default/csphere
+  fi
+  export AUTH_KEY=$AUTH_KEY
+  exec /usr/bin/csphere join --addr=$CONTROLLER_ADDR
+end script

--- a/init/upstart/docker.conf
+++ b/init/upstart/docker.conf
@@ -1,0 +1,58 @@
+description "Docker daemon"
+
+start on runlevel [23]
+stop on runlevel [!2345]
+limit nofile 524288 1048576
+limit nproc 524288 1048576
+
+respawn
+
+pre-start script
+  if grep -v '^#' /etc/fstab | grep -q cgroup \
+    || [ ! -e /proc/cgroups ] ; then
+    exit 0
+  fi
+  [ ! -e /cgroup ] &&  mkdir /cgroup
+  if ! mountpoint -q /cgroup; then
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup  /cgroup
+  fi
+  (
+          set -x 
+    cd /cgroup
+    for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+      mkdir -p $sys
+      if ! mountpoint -q $sys; then
+        if ! mount -n -t cgroup -o $sys cgroup $sys; then
+          rmdir $sys || true
+        fi
+      fi
+    done
+  )
+end script
+
+script
+  # modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+  DOCKER=/usr/local/bin/$UPSTART_JOB
+  DOCKER_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  exec "$DOCKER" -d $DOCKER_OPTS
+end script
+
+# Don't emit "started" event until docker.sock is ready.
+# See https://github.com/docker/docker/issues/6647
+post-start script
+  DOCKER_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+    while ! [ -e /var/run/docker.sock ]; do
+      initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
+      echo "Waiting for /var/run/docker.sock"
+      sleep 0.1
+    done
+    echo "/var/run/docker.sock is up"
+  fi
+end script

--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,10 @@ prepare_csphere() {
     chcon -Rt svirt_sandbox_file_t $DATA_DIR >/dev/null 2>&1 || true
   fi
 
+  if [ "$ROLE" = "agent" ]; then
+    return 0
+  fi
+
   CSPHERE_VERSION=$($curl https://csphere.cn/docs/latest-version.txt)
   if docker images|grep 'csphere/csphere'|grep -q $CSPHERE_VERSION; then
     echo "cSphere Docker image existed "

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ HAS_DOCKER=true
 DOCKER_REPO_URL=https://get.docker.com
 DEFAULT_DATA_DIR="/data/csphere"
 CONTROLLER_PORT=${CONTROLLER_PORT:-1016}
-ASSETS_URL=${ASSETS_URL:-"https://github.com/nicescale/docker-machine/archive/master.tar.gz"}
+ASSETS_URL=${ASSETS_URL:-"https://github.com/nicescale/docker-machine/archive/0.11.tar.gz"}
 #CSPHERE_IMAGE=${CSPHERE_IMAGE:-"csphere/csphere"}
 
 CSPHERE_IMAGE=http://csphere-image.stor.sinaapp.com/csphere.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,9 @@ fi
 trap cleanup EXIT
 
 mkdir -p $TMP_PATH
+if [ "$ROLE" = "agent" -a -n "$CONTROLLER_IP" ]; then
+  ASSETS_URL="http://$CONTROLLER_IP:$CONTROLLER_PORT/api/_download?file=install_scripts"
+fi
 $curl $ASSETS_URL | tar -C $TMP_PATH -zx
 ASSETS_DIR=$(dirname $(dirname $(find $TMP_PATH -name docker.service)))
 [ -d /etc/default ] || mkdir /etc/default
@@ -299,6 +302,7 @@ EOS
   case "$init_sys" in 
     upstart)
       mv $ASSETS_DIR/upstart/csphere-agent.conf /etc/init/
+      initctl stop csphere-agent || true
       initctl start csphere-agent
       ;;
     systemd)


### PR DESCRIPTION
## 使用方法
```bash
AUTH_KEY=helloworld ROLE=agent CONTROLLER_IP=192.168.122.122 CONTROLLER_PORT=1016 DATA_DIR=/data/csphere ./install.sh
```

## 变更
1. agent进程运行直接运行于宿主机上
2. 当`ROLE==agent`时不再从公网获取安装资源，加快安装速度

## 测试情况
* [x] Ubuntu 14.04
* [x] CentOS 6.5
* [ ] Debian 7
* [ ] Debian 8
* [ ] CentOS 7
* [ ] Fedora 20
* [ ] Fedora 21
* [ ] Boot2Docker
* [ ] CoreOS
* [ ] AWS AMI